### PR TITLE
Support gem development

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This extension contributes the following settings:
 * `rbs-helper.signature-directory`: The name of the signature directory
 * `rbs-helper.signature-prototype-directory`: The name of the signature prototype directory
 * `rbs-helper.copy-signature-prototype-on-create`: Copy the signature prototype file on creating a new RBS file
+* `rbs-helper.strip-lib-directory`: Strip `lib/` directory from the filename of signature. Useful for gem development
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
           "type": "boolean",
           "description": "Copy the signature prototype file on creating a new RBS file",
           "default": true
+        },
+        "rbs-helper.strip-lib-directory": {
+          "type": "boolean",
+          "description": "Strip lib/ directory from the filename of signature. Useful for gem development",
+          "default": true
         }
       }
     }

--- a/test/lib/http.rb
+++ b/test/lib/http.rb
@@ -1,0 +1,2 @@
+module Http
+end

--- a/test/sig/prototype/http.rbs
+++ b/test/sig/prototype/http.rbs
@@ -1,0 +1,2 @@
+module Http
+end


### PR DESCRIPTION
On gem development, .rb files are usually placed under lib/ directory. This adds a new configuration "strip-lib-directory" to strip lib/ direcotry on searching the signature file
(ex. lib/foo.rb -> sig/handwritten/foo.rbs)