### PR TITLE
deps: Downgrade @types/vscode to 1.93.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"
+    ignore:
+      - dependency-name: "@types/vscode"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "24.x",
-        "@types/vscode": "^1.103.0",
+        "@types/vscode": "^1.93.0",
         "@vscode/test-electron": "^2.5.2",
         "glob": "^11.0.3",
         "mocha": "^11.7.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.103.0",
+    "@types/vscode": "^1.93.0",
     "@types/glob": "^9.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "24.x",


### PR DESCRIPTION
`vsce publish` expects the version of @types/vscode to match the `engine.vscode` version.  So this downgrades @types/vscode to 1.93.0.

Additionally, this disables the updates for @types/vscode in dependabot.