### PR TITLE
Downgrade @types/node from v25 to v24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "25.x",
+        "@types/node": "24.x",
         "@types/vscode": "^1.110.0",
         "@vscode/test-electron": "^2.5.2",
         "glob": "^13.0.6",
@@ -148,13 +148,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -1430,9 +1430,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/vscode": "^1.110.0",
     "@types/glob": "^9.0.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "25.x",
+    "@types/node": "24.x",
     "glob": "^13.0.6",
     "mocha": "^11.7.5",
     "typescript": "^6.0.2",


### PR DESCRIPTION
## Summary
Downgraded the `@types/node` TypeScript type definitions from version 25.x to 24.x in the development dependencies.

## Changes
- Updated `@types/node` dependency constraint from `25.x` to `24.x` in package.json

## Rationale
This change pins the project to Node.js type definitions v24, which may be necessary for compatibility with the current TypeScript version (v6.0.2) or to maintain stability with existing code that may not yet support the breaking changes introduced in v25.

https://claude.ai/code/session_01HV8Spu6kEE18Aqbw4KGvZ2