### PR TITLE
Configure dependabot to ignore non-LTS Node.js versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
     cooldown:
       default-days: 3
     ignore:
+      # Ignore non-LTS Node.js versions (odd numbers are not LTS)
       - dependency-name: "@types/node"
-        update-types:
-          - "version-update:semver-major"
+        versions: ["25.x", "27.x", "29.x", "31.x", "33.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- Replace the `version-update:semver-major` ignore rule for `@types/node` with an explicit list of odd-numbered versions (25.x, 27.x, 29.x, 31.x, 33.x)
- This allows dependabot to propose even-numbered (LTS) major upgrades while still blocking non-LTS odd releases

## Background

Node.js uses even version numbers for LTS releases. The previous rule blocked all major version bumps, but the desired behavior is to allow LTS major upgrades and only block non-LTS odd releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)