### PR TITLE
Add explicit types to tsconfig for TypeScript 6.0 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true, /* enable all strict type-checking options */
-		"skipLibCheck": true /* Skip type checking of declaration files */
+		"skipLibCheck": true, /* Skip type checking of declaration files */
+		"types": ["node", "mocha"]
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
## Summary

- Add `"types": ["node", "mocha"]` to tsconfig.json

## Background

TypeScript 6.0 changed the default value of `types` from auto-discovery of all installed `@types/*` packages to `[]` (empty array). Without explicitly listing `node` and `mocha`, their global types (`process`, `Buffer`, `describe`, `it`, etc.) would no longer be available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)